### PR TITLE
This basically make the client uploader useable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+credentials.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Support for loading credentials from `credentials.json` in addition to CLI, for all scripts
+
 ## 1.0.0 - 2018-03-08
 ### Added
 - This ChangeLog

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 1.0.1 - 2018-03-30
+### Added
+- Support for local `credentials.json` file in addition to CLI
+- Support for updating auth0 client files, with diffing
+- Support logging to syslog, and verbose/debug options
+
 ### Added
 - Support for loading credentials from `credentials.json` in addition to CLI, for all scripts
 

--- a/credentials.json.example
+++ b/credentials.json.example
@@ -1,0 +1,6 @@
+{
+    "client_id": "",
+    "client_secret": "",
+    "uri": "auth-dev.mozilla.auth0.com"
+}
+

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def read(fname):
 
 setup(
     name="Auth0-ci",
-    version="1.0.0",
+    version="1.0.1",
     author="Guillaume Destuynder",
     author_email="gdestuynder@mozilla.com",
     py_modules=["uploader_login_page", "uploader_rules", "uploader_clients"],

--- a/uploader_clients.py
+++ b/uploader_clients.py
@@ -34,11 +34,20 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
+    # Default credentials loading
+    try:
+        with open('credentials.json', 'r') as fd:
+            credentials = DotDict(json.load(fd))
+            require_creds = False
+    except FileNotFoundError:
+        credentials = DotDict({'client_id': '', 'client_secret': '', 'uri': 'auth-dev.mozilla.auth0.com'})
+        require_creds = True
+
     # Arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('-u', '--uri', default="auth-dev.mozilla.auth0.com", help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', required=True, help='Auth0 client id')
-    parser.add_argument('-s', '--clientsecret', required=True, help='Auth0 client secret')
+    parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
+    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('-r', '--clients-dir', default='clients', help='Directory containing clients in Auth0 format')
     parser.add_argument('-g', '--get-clients-only', action="store_true",
                         help='Get clients from the Auth0 deployment and write them to disk. This will make NO changes '

--- a/uploader_login_page.py
+++ b/uploader_login_page.py
@@ -32,11 +32,20 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
+    # Default credentials loading
+    try:
+        with open('credentials.json', 'r') as fd:
+            credentials = DotDict(json.load(fd))
+            require_creds = False
+    except FileNotFoundError:
+        credentials = DotDict({'client_id': '', 'client_secret': '', 'uri': 'auth-dev.mozilla.auth0.com'})
+        require_creds = True
+
     # Arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('-u', '--uri', default="auth-dev.mozilla.auth0.com", help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', required=True, help='Auth0 client id')
-    parser.add_argument('-s', '--clientsecret', required=True, help='Auth0 client secret')
+    parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
+    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('--default-client', default='VNGM4quJw3Nhx28j8XKVYmu5LcPMCgAH',
                         help='Default Auth0 client id, needed for login page for example')
     parser.add_argument('--login-page', required=True, help='Auth0 hosted login page (HTML)')

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -34,11 +34,20 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
+    # Default credentials loading
+    try:
+        with open('credentials.json', 'r') as fd:
+            credentials = DotDict(json.load(fd))
+            require_creds = False
+    except FileNotFoundError:
+        credentials = DotDict({'client_id': '', 'client_secret': '', 'uri': 'auth-dev.mozilla.auth0.com'})
+        require_creds = True
+
     # Arguments
     parser = argparse.ArgumentParser()
-    parser.add_argument('-u', '--uri', default="auth-dev.mozilla.auth0.com", help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', required=True, help='Auth0 client id')
-    parser.add_argument('-s', '--clientsecret', required=True, help='Auth0 client secret')
+    parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
+    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('-r', '--rules-dir', default='rules', help='Directory containing rules in Auth0 format')
     args = parser.parse_args()
 


### PR DESCRIPTION
Note: its also on pypi

@jdow if you want to test this, create a `credentials.json` file (copy example) and use the "Auth0 CI" integration in auth0 DEV for credentials.

Then start a virtual env, `pip install -r requirements.txt` and:
`mkdir clients`
`./uploader_clients.py -g -v -d` (you can drop `-v -d` if you want, its just verbose+debug)

This will dump all current clients into the `clients` directory. Edit one (eg change "Description" for leo's test client, or something like that), then:
`./uploader_clients.py --show-diff -v -d` and that's it (you can also drop --show-diff when you are confident your diff is alright)

if that works well we should integrate it to actual CI in a repo where we manage clients, so that we can get PR's from people to update clients.. and make PRs to add them and have them auto-created/deleted/updated if checks pass.