### PR TITLE
bump to 1.0.2 and install scripts as scripts ;-)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 1.0.2 - 1018-04-10
+### Changed
+- Install scripts as.. scripts so that you can use them directly after a `pip install auth0-ci`
+- Removed unused open() call in setup.py
+
 ## 1.0.1 - 2018-03-30
 ### Added
 - Support for local `credentials.json` file in addition to CLI

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,9 @@ import os
 from setuptools import setup
 
 
-def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
-
-
 setup(
     name="Auth0-ci",
-    version="1.0.1",
+    version="1.0.2",
     author="Guillaume Destuynder",
     author_email="gdestuynder@mozilla.com",
     py_modules=["uploader_login_page", "uploader_rules", "uploader_clients"],
@@ -24,6 +20,7 @@ setup(
     keywords="auth0 ci deploy",
     url="https://github.com/mozilla-iam/auth0-ci",
     install_requires=['authzerolib'],
+    scripts=['uploader_clients.py', 'uploader_rules.py', 'uploader_login_page.py'],
     classifiers=["Development Status :: 5 - Production/Stable",
                  "License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"]
 )


### PR DESCRIPTION
so that you can pip install auth0-ci then directly call `uploader_rules.py -blah-blah`