### PR TITLE
Add backup and delete all features to uploader rules

### DIFF
--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -12,8 +12,13 @@ import json
 import logging
 import os
 import sys
-from authzero import AuthZero,AuthZeroRule
+from authzero import AuthZero, AuthZeroRule
 import difflib
+
+
+class NotARulesDirectory(Exception):
+    pass
+
 
 class DotDict(dict):
     """return a dict.item notation for dict()'s"""
@@ -22,16 +27,18 @@ class DotDict(dict):
     __setattr__ = dict.__setitem__
     __delattr__ = dict.__delitem__
 
-    def __init__(self, dct):
-        for key, value in dct.items():
+    def __init__(self, dict_):
+        super().__init__()
+        for key, value in dict_.items():
             if hasattr(value, 'keys'):
                 value = DotDict(value)
             self[key] = value
 
+
 if __name__ == "__main__":
     # Logging
-    formatstr="[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s"
-    logging.basicConfig(format=formatstr, datefmt="%H:%M:%S", stream=sys.stdout)
+    logger_format = "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s"
+    logging.basicConfig(format=logger_format, datefmt="%H:%M:%S", stream=sys.stdout)
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
@@ -50,6 +57,7 @@ if __name__ == "__main__":
     parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
     parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('-r', '--rules-dir', default='rules', help='Directory containing rules in Auth0 format')
+    parser.add_argument('--delete-all-rules-first-causing-outage', action='store_true', help="Before uploading rules, delete all rules causing an outage")
     parser.add_argument('-d', '--dry-run', action='store_true', help="Show what would be done but don't actually make any changes")
     args = parser.parse_args()
 
@@ -67,94 +75,94 @@ if __name__ == "__main__":
 
     # Local rules loader
     if not os.path.isdir(args.rules_dir):
-        raise Exception('NotARulesDirectory' (args.rules_dir))
+        raise NotARulesDirectory(args.rules_dir)
 
     # Process all local rules
     local_rules_files = glob.glob("{}/*.json".format(args.rules_dir))
     local_rules = []
-    for rfile in local_rules_files:
-        logger.debug("Reading local rule configuration {}".format(rfile))
-        rule = AuthZeroRule()
+    for local_rules_file in local_rules_files:
+        logger.debug("Reading local rule configuration {}".format(local_rules_file))
+        local_rule = AuthZeroRule()
         # Overload the object with our own statuses
-        rule.is_new = False
-        rule.is_the_same = False
+        local_rule.is_new = False
+        local_rule.is_the_same = False
 
         # Rule name comes from the filename with the auth0 format
-        rule.name = rfile.split('/')[-1].split('.')[:-1][0]
-        with open(rfile, 'r') as fd:
+        local_rule.name = local_rules_file.split('/')[-1].split('.')[:-1][0]
+        with open(local_rules_file, 'r') as fd:
             rule_conf = DotDict(json.load(fd))
-        rule.enabled = bool(rule_conf.enabled)
-        rule.order = int(rule_conf.order)
+        local_rule.enabled = bool(rule_conf.enabled)
+        local_rule.order = int(rule_conf.order)
 
-        rcfile = rfile.rstrip('on') # Equivalent to s/blah.json/blah.js/
-        logger.debug("Reading local rule code {}".format(rcfile))
-        with open(rcfile, 'r') as fd:
-            rule.script = fd.read()
+        local_rules_file_js = local_rules_file.rstrip('on')  # Equivalent to s/blah.json/blah.js/
+        logger.debug("Reading local rule code {}".format(local_rules_file_js))
+        with open(local_rules_file_js, 'r') as fd:
+            local_rule.script = fd.read()
 
         # Match with existing remote rule if we need to update.. this uses the rule name!
-        rule_nr = [i for i,_ in enumerate(remote_rules) if _.get('name') == rule.name]
-        if rule_nr:
+        remote_rule_indexes = [i for i, _ in enumerate(remote_rules) if _.get('name') == local_rule.name]
+        if remote_rule_indexes:
             # If there's multi matches it means we have duplicate rule names and we're screwed.
             # To fix that we'd need to change the auth0 local format to use rule ids (which we could eventually)
-            if (len(rule_nr) > 1):
-                raise Exception('RuleMatchByNameFailed', (rule.name, rule_nr))
-            rule.id = remote_rules[rule_nr[0]].get('id')
-            rule.is_new = False
+            if len(remote_rule_indexes) > 1:
+                raise Exception('RuleMatchByNameFailed', (local_rule.name, remote_rule_indexes))
+            remote_rule_index = remote_rule_indexes[0]
+            local_rule.id = remote_rules[remote_rule_index].get('id')
+            local_rule.is_new = False
 
             # Is the rule different?
-            remote_rule = remote_rules[rule_nr[0]]
-            rule.is_the_same = (rule.script == remote_rule.get('script')) & (rule.enabled == bool(remote_rule.get('enabled'))) \
-                   & (rule.stage == remote_rule.get('stage')) & (rule.order == remote_rule.get('order'))
-            if not rule.is_the_same:
-                logger.debug('Difference found in {} :'.format(rule.name))
-                for line in difflib.unified_diff(remote_rule.get('script').splitlines(), rule.script.splitlines(), fromfile='auth0-{}'.format(rule.name),
-                                         tofile='local-{}'.format(rule.name)):
+            remote_rule = remote_rules[remote_rule_index]
+            local_rule.is_the_same = (
+                    (local_rule.script == remote_rule.get('script')) &
+                    (local_rule.enabled == bool(remote_rule.get('enabled'))) &
+                    (local_rule.stage == remote_rule.get('stage')) &
+                    (local_rule.order == remote_rule.get('order')))
+            if not local_rule.is_the_same:
+                logger.debug('Difference found in {} :'.format(local_rule.name))
+                for line in difflib.unified_diff(
+                        remote_rule.get('script').splitlines(),
+                        local_rule.script.splitlines(),
+                        fromfile='auth0-{}'.format(local_rule.name),
+                        tofile='local-{}'.format(local_rule.name)):
                     logger.debug(line)
         else:
             # No remote rule match, so it's a new rule
-            logger.debug('Rule only exists locally, considered new and to be created: {}'.format(rule.name))
-            rule.is_new = True
+            logger.debug('Rule only exists locally, considered new and to be created: {}'.format(local_rule.name))
+            local_rule.is_new = True
 
-        if not rule.validate():
-            logger.error('Rule failed validation: {}'.format(rule.name))
+        if not local_rule.validate():
+            logger.error('Rule failed validation: {}'.format(local_rule.name))
             sys.exit(127)
         else:
-            local_rules.append(rule)
+            local_rules.append(local_rule)
     logger.debug("Found {} local rules".format(len(local_rules)))
 
     # Find dead rules (i.e. to remove/rules that only exist remotely)
-    remove_rules = []
-    for rl in local_rules:
-        ok = False
-        rr = None
-        for rr in remote_rules:
-            if (rl.id == rr.get('id')) or (rl.is_new):
-                ok = True
-                continue
-        if not ok and rr is not None:
-            remove_rules.append(rr)
-    logger.debug("Found {} rules that not longer exist locally and will be deleted remotely".format(len(remove_rules)))
+    rules_to_remove = [x for x in remote_rules if x.get('id') not in [y.id for y in local_rules]]
+    logger.debug("Found {} rules that not longer exist locally and will be deleted remotely".format(len(rules_to_remove)))
 
     # Update or create (or delete) rules as needed
     ## Delete first in case we need to get some order numbers free'd
-    for r in remove_rules:
+    for rule in rules_to_remove:
         logger.debug("[-] {}Removing rule {} ({}) from Auth0".format(
-            dry_run_message, r.name, r.id))
-        not args.dry_run and authzero.delete_rule(r.id)
+            dry_run_message, rule.name, rule.id))
+        if not args.dry_run:
+            authzero.delete_rule(rule.id)
 
     ## Update & Create (I believe this may be atomic swaps for updates)
-    for r in local_rules:
-        if r.is_new:
+    for local_rule in local_rules:
+        if local_rule.is_new:
             logger.debug("[+] {}Creating new rule {} on Auth0".format(
-                dry_run_message, r.name))
+                dry_run_message, local_rule.name))
             if not args.dry_run:
-                ret = authzero.create_rule(r)
-                logger.debug("+ New rule created with id {}".format(ret.get('id')))
-        elif r.is_the_same:
-            logger.debug("[=] Rule {} is unchanged, will not update".format(r.name))
+                result = authzero.create_rule(local_rule)
+                logger.debug("+ New rule created with id {}".format(result.get('id')))
+        elif local_rule.is_the_same:
+            logger.debug("[=] Rule {} is unchanged, will not update".format(local_rule.name))
         else:
             logger.debug("[~] {}Updating rule {} ({}) on Auth0".format(
-                dry_run_message, r.name, r.id))
-            not args.dry_run and authzero.update_rule(r.id, r)
+                dry_run_message, local_rule.name, local_rule.id))
+            if not args.dry_run:
+                authzero.update_rule(local_rule.id, local_rule)
 
     sys.exit(0)

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -107,6 +107,10 @@ if __name__ == "__main__":
             if not args.dry_run:
                 with open(js_filename, 'x') as f:
                     f.write(rule['script'])
+        print("To restore from this backup run {} --rules-dir {}".format(
+            os.path.basename(__file__),
+            args.backup_rules_to_directory
+        ))
         sys.exit(0)
 
     # Local rules loader

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -169,9 +169,9 @@ if __name__ == "__main__":
     ## Delete first in case we need to get some order numbers free'd
     for rule in rules_to_remove:
         logger.debug("[-] {}Removing rule {} ({}) from Auth0".format(
-            dry_run_message, rule.name, rule.id))
+            dry_run_message, rule['name'], rule['id']))
         if not args.dry_run:
-            authzero.delete_rule(rule.id)
+            authzero.delete_rule(rule['id'])
 
     ## Update & Create (I believe this may be atomic swaps for updates)
     for local_rule in local_rules:


### PR DESCRIPTION
* Add output indicating how to restore from backup
* Add --backup-rules-to-directory option
* Fix bug preventing rule deletion
* Add new --delete-all-rules-first-causing-outage option
  * This will
    * enable maintenance mode denying all logins globally
    * delete all remote rules (except the maintenance rule)
    * create all new rules (except the maintenance rule)
    * disable maintenance mode
* Expand variable names for clarity
  * Simplify method to build list of rules to be deleted

# Usage

With these new features, a production deploy would look like this

```
# confirm credentials.json contains production credentials
./uploader_rules.py --backup-rules-to-directory production-backup

./uploader_rules.py --dry-run --rules-dir ../auth0-deploy/rules

./uploader_rules.py --rules-dir ../auth0-deploy/rules

# test production
# if there's a problem

./uploader_rules.py --dry-run --rules-dir production-backup
./uploader_rules.py --rules-dir production-backup

# test production
# if there's still a problem

./uploader_rules.py --dry-run --delete-all-rules-first-causing-outage --rules-dir production-backup
./uploader_rules.py --delete-all-rules-first-causing-outage --rules-dir production-backup
```