### PR TITLE
Fix errors in uploader, add support for .config and path for config file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ and can instead instantiate the tools like this
 SCOPES: `update:clients`
 
 ```
-usage: uploader_login_page.py [-h] [-u URI] -c CLIENTID -s CLIENTSECRET
+usage: uploader_login_page.py [-h] [-u URI] -i CLIENTID -s CLIENTSECRET
                               [--default-client DEFAULT_CLIENT] --login-page
                               LOGIN_PAGE
 ```
 
-Example: `./uploader_login_page.py -u auth-dev.mozilla.auth0.com -c AAA -s BBB --default-client CCC --login-page some.html`
+Example: `./uploader_login_page.py -u auth-dev.mozilla.auth0.com -i AAA -s BBB --default-client CCC --login-page some.html`
 
 Note that `CCC` above represents a special Auth0 "default" client. You can find this `client_id` by going to the "hosted
 page" setup in Auth0 and looking at your web-browser dev tools network tab. Click "preview page" and look for the
@@ -74,7 +74,7 @@ page" setup in Auth0 and looking at your web-browser dev tools network tab. Clic
 SCOPES: `read:rules`, `update:rules`, `delete:rules`, `create:rules`
 
 ```
-usage: uploader_rules.py [-h] [-u URI] [-c CLIENTID] [-s CLIENTSECRET]
+usage: uploader_rules.py [-h] [-u URI] [-i CLIENTID] [-s CLIENTSECRET]
                          [-r RULES_DIR] [-b DIRECTORY]
                          [--delete-all-rules-first-causing-outage] [-d]
 ```
@@ -133,17 +133,17 @@ To do deploy a set of changed rules safely
 ### uploader_clients.py
 SCOPES: `read:clients`, `update:clients`, `delete:clients`, `create:clients`
 ```
-usage: uploader_clients.py [-h] [-u URI] -c CLIENTID -s CLIENTSECRET
+usage: uploader_clients.py [-h] [-u URI] -i CLIENTID -s CLIENTSECRET
                            [-r CLIENTS_DIR] [-g]
-uploader_clients.py: error: the following arguments are required: -c/--clientid, -s/--clientsecret
+uploader_clients.py: error: the following arguments are required: -i/--clientid, -s/--clientsecret
 ```
 
-Example: `./uploader_clients.py -u auth-dev.mozilla.auth0.com -c AAA -s BBB -r clients`
+Example: `./uploader_clients.py -u auth-dev.mozilla.auth0.com -i AAA -s BBB -r clients`
 
 Where the `clients` directory contains JSON formated Auth0 client descriptions. You can get all current clients from
 your Auth0 deployment to provision the initial setup with:
 
-Example: `./uploader_clients.py -u auth-dev.mozilla.auth0.com -c AAA -s BBB -r clients -g`
+Example: `./uploader_clients.py -u auth-dev.mozilla.auth0.com -i AAA -s BBB -r clients -g`
 
 A client JSON file looks such as this:
 

--- a/uploader_clients.py
+++ b/uploader_clients.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
     # Arguments
     parser = argparse.ArgumentParser()
     parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-i', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
     parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('-d', '--debug', action="store_true", help='Enable debug mode')
     parser.add_argument('-v', '--verbose', action="store_true", help='Show log messages on stderr instead of sending to syslog')

--- a/uploader_login_page.py
+++ b/uploader_login_page.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
     # Arguments
     parser = argparse.ArgumentParser()
     parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-i', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
     parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('--default-client', default='VNGM4quJw3Nhx28j8XKVYmu5LcPMCgAH',
                         help='Default Auth0 client id, needed for login page for example')

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -47,27 +47,42 @@ def empty_directory(directory):
             "which doesn't exist or an empty directory".format(directory))
     return directory
 
+def parse_credential_files(filenames: list) -> tuple:
+    # load the credentials file
+    credentials = DotDict({
+        'client_id': '',
+        'client_secret': '',
+        'uri': 'auth-dev.mozilla.auth0.com',
+    })
+    require_creds = True
+    for filename in filenames:
+        if os.path.exists(filename):
+            with open(filename, 'r') as fd:
+                credentials = DotDict(json.load(fd))
+                require_creds = False
+
+    return (credentials, require_creds)
 
 if __name__ == "__main__":
+    CREDENTIAL_FILES = [
+        os.path.join(os.path.expanduser('~'), '.config', 'auth0', 'credentials.json'),
+        'credentials.json',
+    ]
+
     # Logging
     logger_format = "[%(asctime)s] %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s"
     logging.basicConfig(format=logger_format, datefmt="%H:%M:%S", stream=sys.stdout)
     logger = logging.getLogger(__name__)
     logger.setLevel(logging.DEBUG)
 
-    # Default credentials loading
-    try:
-        with open('credentials.json', 'r') as fd:
-            credentials = DotDict(json.load(fd))
-            require_creds = False
-    except FileNotFoundError:
-        credentials = DotDict({'client_id': '', 'client_secret': '', 'uri': 'auth-dev.mozilla.auth0.com'})
-        require_creds = True
+    # Load the default credentials
+    credentials, require_creds = parse_credential_files(CREDENTIAL_FILES)
 
     # Arguments
     parser = argparse.ArgumentParser()
+    parser.add_argument('-c', '--config', default=None, help='Path to credentials.json')
     parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
-    parser.add_argument('-c', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
+    parser.add_argument('-i', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
     parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
     parser.add_argument('-r', '--rules-dir', default='rules', help='Directory containing rules in Auth0 format')
     parser.add_argument('-b', '--backup-rules-to-directory', type=empty_directory, metavar='DIRECTORY', help='Download all rules from the API and save them to this directory.')
@@ -75,9 +90,29 @@ if __name__ == "__main__":
     parser.add_argument('-d', '--dry-run', action='store_true', help="Show what would be done but don't actually make any changes")
     args = parser.parse_args()
 
-    config = DotDict({'client_id': args.clientid, 'client_secret': args.clientsecret, 'uri': args.uri})
-    authzero = AuthZero(config)
-    authzero.get_access_token()
+    # if we specify a file manually, open that, otherwise walk through the list of CREDENTIAL_FILES
+    if args.config is not None:
+        if os.path.exists(args.config):
+            credentials, require_creds = parse_credential_files([args.config])
+            args.clientid = credentials.client_id
+            args.clientsecret = credentials.client_secret
+            args.uri = credentials.uri
+        else:
+            logger.error('Credentials file {} does not exist'.format(args.config))
+            sys.exit(1)
+
+    authzero = AuthZero({
+        'client_id': args.clientid,
+        'client_secret': args.clientsecret,
+        'uri': args.uri}
+    )
+
+    try:
+        authzero.get_access_token()
+    except Exception:
+        logger.error('Unable to get access token for client_id: {}'.format(args.clientid))
+        sys.exit(1)
+
     logger.debug("Got access token for client_id:{}".format(args.clientid))
     dry_run_message = 'Dry Run : Action not taken : ' if args.dry_run else ''
 
@@ -184,6 +219,10 @@ if __name__ == "__main__":
         else:
             local_rules.append(local_rule)
     logger.debug("Found {} local rules".format(len(local_rules)))
+
+    if (len(local_rules)) == 0:
+        logger.error("Exiting to prevent deletion of all rules")
+        sys.exit(1)
 
     if args.delete_all_rules_first_causing_outage:
         rules_to_remove = [x for x in remote_rules if x.get('name') != MAINTENANCE_RULE_NAME]

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -54,14 +54,12 @@ def parse_credential_files(filenames: list) -> tuple:
         'client_secret': '',
         'uri': 'auth-dev.mozilla.auth0.com',
     })
-    require_creds = True
     for filename in filenames:
         if os.path.exists(filename):
             with open(filename, 'r') as fd:
                 credentials = DotDict(json.load(fd))
-                require_creds = False
 
-    return (credentials, require_creds)
+    return credentials
 
 if __name__ == "__main__":
     CREDENTIAL_FILES = [
@@ -76,7 +74,7 @@ if __name__ == "__main__":
     logger.setLevel(logging.DEBUG)
 
     # Load the default credentials
-    credentials, require_creds = parse_credential_files(CREDENTIAL_FILES)
+    credentials = parse_credential_files(CREDENTIAL_FILES)
 
     # Arguments
     parser = argparse.ArgumentParser()
@@ -93,7 +91,7 @@ if __name__ == "__main__":
     # if we specify a file manually, open that, otherwise walk through the list of CREDENTIAL_FILES
     if args.config is not None:
         if os.path.exists(args.config):
-            credentials, require_creds = parse_credential_files([args.config])
+            credentials = parse_credential_files([args.config])
             args.clientid = credentials.client_id
             args.clientsecret = credentials.client_secret
             args.uri = credentials.uri

--- a/uploader_rules.py
+++ b/uploader_rules.py
@@ -82,8 +82,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument('-c', '--config', default=None, help='Path to credentials.json')
     parser.add_argument('-u', '--uri', default=credentials.uri, help='URI to Auth0 management API')
-    parser.add_argument('-i', '--clientid', default=credentials.client_id, required=require_creds, help='Auth0 client id')
-    parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, required=require_creds, help='Auth0 client secret')
+    parser.add_argument('-i', '--clientid', default=credentials.client_id, help='Auth0 client id')
+    parser.add_argument('-s', '--clientsecret', default=credentials.client_secret, help='Auth0 client secret')
     parser.add_argument('-r', '--rules-dir', default='rules', help='Directory containing rules in Auth0 format')
     parser.add_argument('-b', '--backup-rules-to-directory', type=empty_directory, metavar='DIRECTORY', help='Download all rules from the API and save them to this directory.')
     parser.add_argument('--delete-all-rules-first-causing-outage', action='store_true', help="Before uploading rules, delete all rules causing an outage")
@@ -100,6 +100,10 @@ if __name__ == "__main__":
         else:
             logger.error('Credentials file {} does not exist'.format(args.config))
             sys.exit(1)
+
+    if not args.clientid or not args.clientsecret:
+        logger.error('Missing client id and/or client secret')
+        sys.exit(1)
 
     authzero = AuthZero({
         'client_id': args.clientid,
@@ -220,7 +224,7 @@ if __name__ == "__main__":
             local_rules.append(local_rule)
     logger.debug("Found {} local rules".format(len(local_rules)))
 
-    if (len(local_rules)) == 0:
+    if len(local_rules) == 0:
         logger.error("Exiting to prevent deletion of all rules")
         sys.exit(1)
 


### PR DESCRIPTION
Cleans up a bunch of code, also adds checks for two different (currently unchecked) error conditions.

Note that this will require a change to the Makefile in `auth0-deploy`, as `-c` has been changed to `-i`. This is reflected here: https://github.com/mozilla-iam/auth0-deploy/pull/317