### PR TITLE
bump authzerolib dependency to 1.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-authzerolib==1.0.2
+authzerolib==1.1.0


### PR DESCRIPTION
This updates the authozerolib dependency of the auth0-ci repository to use the fixed 1.1.0 version.